### PR TITLE
use 'echo' in included backup conf definition to avoid error due to ``s

### DIFF
--- a/templates/rsnapshot.backup.conf.erb
+++ b/templates/rsnapshot.backup.conf.erb
@@ -3,5 +3,5 @@
 #	<%= comment %>
 #
 <% end -%>
-backup	<%= source %>	<%= name.chomp('/')+'/' %><% if options != [] %>	<%= options.join(',') %><% end %>
+echo -e backup\t\t<%= source %>\t\t<%= name.chomp('/')+'/' %><% if options != [] %>\t\t<%= options.join(',') %><% end %>
 


### PR DESCRIPTION
Currently, master tries to include a set of rsnapshot backup definitions by including a shell script like:
include_conf `/path/to/include.sh`
include.sh does something like: cat /path/to/include.d/*.conf

Each of those files looks like "backup\t\t..." and contains a definition intended to be interpolated where the first include_conf directive is used. However, at least under bash on the gentoo boxes I'm working on, that results in a shell error complaining that "backup" is not a valid command. It's trying to execute that line, due to the `` backticks.

I'm not sure whether this is by design (and there's some issue with my environment), whether Puppet or rsnapshot have changed their behaviour, or whether this is actually just a bug, however this 1 line change fixes the problem by forcing the line through "echo".

I'm happy to discuss or provide more example of how to reproduce the issue.
